### PR TITLE
[FIX] Moved serialize-to-js from dev to normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "commander": "^2.8.1",
     "js-select": ">=0.6.0",
     "js-yaml": "~2.1.3",
-    "mergee": ">=0.2.2"
+    "mergee": ">=0.2.2",
+    "serialize-to-js": ">=0.1.1"
   },
   "devDependencies": {
     "mocha": ">=0.17.0",
-    "serialize-to-js": ">=0.1.1",
     "streamss": ">=0.2.4",
     "ua-parser2": "latest"
   },


### PR DESCRIPTION
Servus,

serialize-to-js should not be a development but a normal dependency as it is required by the library in production mode.

Greetings

Ben
